### PR TITLE
Add optional memviz installation on the app VM

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,32 @@ It does assume password `pass` port `12000` and has my own DNS domain hardcoded 
 
 You are best to run with `app_enabled=true` to spawn a client app machine and have memtier CLI already setup for you on the same colocated network & infrastructure.
 
+## Optional memviz
+
+`memviz` is off by default and installs on the existing app VM only when enabled.
+
+Example:
+```
+app = 1
+app_machine_type = "e2-standard-2"
+clustersize = 1
+memviz_enabled = true
+```
+
+Advanced overrides:
+```
+memviz_port = 3000
+memviz_repo_url = "https://github.com/itay-ct/memviz.git"
+memviz_repo_ref = "main"
+```
+
+After `terraform apply`, test with:
+```
+systemctl status memviz
+curl http://127.0.0.1:3000/api/meta
+curl http://app.<yourname>-<env>.<dns_zone>:3000/api/meta
+```
+
 ## Running GKE
 
 With `gke_enabled=true` Terraform will create a GKE cluster and you can configure machines type and node pool machine count.
@@ -248,4 +274,3 @@ https://github.com/radeksimko/terraform-examples/tree/master/google-consul
 https://medium.com/slalom-technology/a-complete-gcp-environment-with-terraform-c087190366f0
 
 https://gist.github.com/smford22/54aa5e96701430f1bb0ea6e1a502d23a
-

--- a/instance.tf
+++ b/instance.tf
@@ -2,11 +2,11 @@ resource "google_compute_instance" "app" {
   count = var.app
 
   name         = count.index <= 0 ? "${var.yourname}-${var.env}-app" : "${var.yourname}-${var.env}-app-${count.index}"
-  machine_type = "n2-standard-32" // n2-highcpu-16" // for memtier/TLS we need a highcpu machine
+  machine_type = var.app_machine_type
   // "c3-highmem-44" is also an extreme choice with more network bandwidth
   //machine_type = var.machine_type
   zone         = "${var.region_name}-${var.region_zones[0]}"
-  tags         = ["ssh", "http"]
+  tags         = concat(["ssh", "http"], var.memviz_enabled ? ["memviz"] : [])
   boot_disk {
     initialize_params {
       image = "ubuntu-minimal-2204-jammy-v20250311" //"ubuntu-minimal-2004-lts"
@@ -21,7 +21,11 @@ resource "google_compute_instance" "app" {
     ssh-keys = "ubuntu:${file("~/.ssh/google_compute_engine.pub")}"
     startup-script = templatefile("${path.module}/scripts/app.sh", {
       cluster_dns_suffix = "${var.yourname}-${var.env}.${var.dns_zone_dns_name}",
-      nodes  = "${var.clustersize}"
+      nodes  = "${var.clustersize}",
+      memviz_enabled  = var.memviz_enabled,
+      memviz_port     = var.memviz_port,
+      memviz_repo_url = var.memviz_repo_url,
+      memviz_repo_ref = var.memviz_repo_ref
     })
   }
   network_interface {
@@ -174,7 +178,7 @@ resource "google_dns_record_set" "name_servers" {
 locals {
   n1 = google_dns_record_set.node1.name
   nX = [for xx in google_dns_record_set.nodeX : xx.name]
-} 
+}
 
 resource "random_password" "password" {
   length           = 12

--- a/main.tf
+++ b/main.tf
@@ -38,3 +38,6 @@ EOT
 output "how_to_ssh_to_app" {
   value = var.app>0 ? "gcloud compute ssh ${google_compute_instance.app.0.name}" : ""
 }
+output "memviz_url" {
+  value = var.memviz_enabled && var.app > 0 ? "http://app.${var.yourname}-${var.env}.${var.dns_zone_dns_name}:${var.memviz_port}" : ""
+}

--- a/scripts/app.sh
+++ b/scripts/app.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+MEMVIZ_ENABLED="${memviz_enabled}"
+MEMVIZ_PORT="${memviz_port}"
+MEMVIZ_REPO_URL="${memviz_repo_url}"
+MEMVIZ_REPO_REF="${memviz_repo_ref}"
+
 ## commons
 
 apt-get -y update
@@ -59,3 +64,53 @@ chmod u+x scripts/*.sh
 # for "sudo su - ubuntu"
 chown -R ubuntu:ubuntu /home/ubuntu/install
 chown -R ubuntu:ubuntu /home/ubuntu/.local
+
+if [ "$MEMVIZ_ENABLED" = "true" ]; then
+  apt-get install -y curl ca-certificates gnupg git
+
+  mkdir -p /etc/apt/keyrings
+  curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+  echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" > /etc/apt/sources.list.d/nodesource.list
+  apt-get -y update
+  apt-get install -y nodejs
+
+  install -d -o ubuntu -g ubuntu /opt
+  if [ ! -d /opt/memviz/.git ]; then
+    rm -rf /opt/memviz
+    sudo -u ubuntu git clone "$MEMVIZ_REPO_URL" /opt/memviz
+  fi
+
+  cd /opt/memviz
+  sudo -u ubuntu git remote set-url origin "$MEMVIZ_REPO_URL"
+  sudo -u ubuntu git fetch --all --tags
+  if sudo -u ubuntu git show-ref --verify --quiet "refs/remotes/origin/$MEMVIZ_REPO_REF"; then
+    sudo -u ubuntu git checkout -B "$MEMVIZ_REPO_REF" "origin/$MEMVIZ_REPO_REF"
+  else
+    sudo -u ubuntu git checkout "$MEMVIZ_REPO_REF"
+  fi
+  sudo -u ubuntu npm install
+  sudo -u ubuntu npm run build
+
+  cat >/etc/systemd/system/memviz.service <<EOF
+[Unit]
+Description=memviz
+After=network.target
+
+[Service]
+Type=simple
+User=ubuntu
+WorkingDirectory=/opt/memviz
+Environment=NODE_ENV=production
+Environment=PORT=$MEMVIZ_PORT
+ExecStart=/usr/bin/npm run start
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+  systemctl daemon-reload
+  systemctl enable memviz
+  systemctl restart memviz
+fi

--- a/variable.tf
+++ b/variable.tf
@@ -75,6 +75,31 @@ variable "app" {
   # You can for example use 3+ for some more realistic installation
   default = "1"
 }
+variable "app_machine_type" {
+  description = "Machine type for the optional app/memtier VM."
+  type        = string
+  default     = "n2-standard-32"
+}
+variable "memviz_enabled" {
+  description = "Install memviz on the existing app VM."
+  type        = bool
+  default     = false
+}
+variable "memviz_port" {
+  description = "Port used by the memviz service on the app VM."
+  type        = number
+  default     = 3000
+}
+variable "memviz_repo_url" {
+  description = "Git repository URL for memviz."
+  type        = string
+  default     = "https://github.com/itay-ct/memviz.git"
+}
+variable "memviz_repo_ref" {
+  description = "Branch, tag, or ref to checkout for memviz."
+  type        = string
+  default     = "main"
+}
 
 // other possible edits ************************************* Redis Cloud PRO
 variable "rc_enabled" {
@@ -124,4 +149,3 @@ variable "rs_public_subnet" {
 variable "region_zones" {
   default = ["b", "c", "d"]
 }
-

--- a/vpc.tf
+++ b/vpc.tf
@@ -6,10 +6,10 @@ resource "google_compute_network" "vpc" {
 resource "google_compute_firewall" "allow-internal" {
   name    = "${var.yourname}-${var.env}-fw-allow-internal"
   network = google_compute_network.vpc.name
-  allow {
+allow {
     protocol = "icmp"
   }
-  allow {
+allow {
     protocol = "tcp"
     ports    = ["0-65535"]
   }
@@ -25,12 +25,12 @@ resource "google_compute_firewall" "allow-internal" {
 resource "google_compute_firewall" "allow-http" {
   name    = "${var.yourname}-${var.env}-fw-allow-http"
   network = google_compute_network.vpc.name
-allow {
+  allow {
     protocol = "tcp"
     ports    = ["10000-19999", "8443", "8001", "8070", "8071", "9081", "9443", "8080", "443"]
     # https://docs.redislabs.com/latest/rs/administering/designing-production/networking/port-configurations/?s=port
   }
-allow {
+  allow {
     protocol = "udp"
     ports    = ["53", "5353"]
   }
@@ -47,4 +47,16 @@ resource "google_compute_firewall" "allow-bastion" {
   target_tags = ["ssh"]
   source_ranges = [ "0.0.0.0/0" ]
 
+}
+
+resource "google_compute_firewall" "allow-memviz" {
+  count   = var.memviz_enabled && var.app > 0 ? 1 : 0
+  name    = "${var.yourname}-${var.env}-fw-allow-memviz"
+  network = google_compute_network.vpc.name
+  allow {
+    protocol = "tcp"
+    ports    = [tostring(var.memviz_port)]
+  }
+  target_tags   = ["memviz"]
+  source_ranges = ["0.0.0.0/0"]
 }


### PR DESCRIPTION
## What changed

This adds an optional `memviz` installation path on the existing app VM.

When `memviz_enabled = true`, Terraform now:
- passes memviz settings into the app VM startup script
- installs Node.js and clones/builds the memviz app on the app VM
- creates a `systemd` service for memviz
- opens a dedicated firewall rule for the memviz port
- exposes a `memviz_url` Terraform output
- documents the new workflow in the README

It also adds `app_machine_type` so the app VM can be downsized when it is used for memviz rather than only for heavier memtier workloads.

## Why

The goal is to make memviz very easy to enable in this environment without requiring a separate host or manual setup steps after `terraform apply`.

## Important behavior notes

This PR intentionally makes `memviz_enabled = true` the full on-switch.

That means:
- memviz is exposed externally on `memviz_port` (default `3000`) via a new firewall rule
- the default `memviz_repo_url` points to `https://github.com/itay-ct/memviz.git`

These choices were intentional to keep setup simple and immediately usable.

## Validation

I validated the change with:
- `terraform validate`
- `bash -n scripts/app.sh`

## Impact

Users who do not enable `memviz_enabled` should see no behavior change.
Users who enable it get a directly reachable memviz instance on the existing app VM.
